### PR TITLE
feat: AOT and Trimming Compatible

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -23,3 +23,46 @@ Sometimes these need to be reinstalled after a Visual Studio update.
 
 WasmBrowser projects must appear alphabetically before RCL projects.  See: https://github.com/dotnet/aspnetcore/issues/55105
 
+## Publish and run with dotnet serve
+
+The WASM test hosts can be published (see README § AOT and trimming for AOT/trimming options) then served locally with **dotnet serve**.
+
+### Publish
+
+From the repo root:
+
+```bash
+dotnet publish SerratedJSInterop.Tests.BlazorWasm\SerratedJSInterop.Tests.BlazorWasm.csproj -c Release -o publish\BlazorWasm
+dotnet publish SerratedJSInterop.Tests.WasmBrowser\0SerratedJSInterop.Tests.WasmBrowser.csproj -c Release -o publish\WasmBrowser
+```
+
+### Install dotnet serve
+
+```bash
+dotnet tool install --global dotnet-serve
+```
+
+### Serve the published output
+
+Serve the **wwwroot** of each publish so that `index.html` is at the site root. From the repo root:
+
+**Blazor WASM:**
+
+```bash
+dotnet serve -d publish\BlazorWasm\wwwroot -p 5100 -o
+```
+
+**WasmBrowser** (if that project’s `index.html` is in a `wwwroot` subfolder):
+
+```bash
+dotnet serve -d publish\WasmBrowser\wwwroot -p 5101 -o
+```
+
+If WasmBrowser puts `index.html` at the publish root, use `-d publish\WasmBrowser` instead.
+
+- `-d` = directory to serve  
+- `-p` = port  
+- `-o` = open browser when server starts  
+
+Use `-b` to enable Brotli compression on the fly (dotnet serve does not serve the pre-compressed `.br` files from publish).
+

--- a/SerratedDom/SerratedDom.csproj
+++ b/SerratedDom/SerratedDom.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>SerratedSharp.SerratedDom</RootNamespace>
     <AssemblyName>SerratedSharp.SerratedDom</AssemblyName>
     <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SerratedJSInterop.Internal/SerratedJSInterop.Internal.csproj
+++ b/SerratedJSInterop.Internal/SerratedJSInterop.Internal.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>SerratedSharp.SerratedJSInterop.Internal</RootNamespace>
     <AssemblyName>SerratedSharp.SerratedJSInterop.Internal</AssemblyName>
     <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SerratedJSInterop.Tests.BlazorWasm/SerratedJSInterop.Tests.BlazorWasm.csproj
+++ b/SerratedJSInterop.Tests.BlazorWasm/SerratedJSInterop.Tests.BlazorWasm.csproj
@@ -6,6 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
 	  <AssemblyName>SerratedSharp.SerratedJSInterop.Tests.BlazorWasm</AssemblyName>
 	  <RootNamespace>SerratedSharp.SerratedJSInterop.Tests.BlazorWasm</RootNamespace>
+    <!-- AOT and trimming run only on publish (not on build). Validate with: dotnet publish -c Release -->
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <PublishTrimmed>true</PublishTrimmed>
+    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SerratedJSInterop.Tests.Shared/JSObjectExtensionsV2/InvalidTypeCastTests.cs
+++ b/SerratedJSInterop.Tests.Shared/JSObjectExtensionsV2/InvalidTypeCastTests.cs
@@ -1,0 +1,135 @@
+using SerratedSharp.SerratedDom;
+using SerratedSharp.SerratedJSInterop;
+using SerratedSharp.SerratedJQ.Plain;
+using System.Runtime.InteropServices.JavaScript;
+using Wasm;
+
+namespace Tests.Wasm;
+
+public partial class TestsContainer
+{
+    /// <summary>
+    /// Tests that GetJSProperty throws InvalidCastException when requesting an incompatible type.
+    /// For example, requesting an int[] when the JS property is a string.
+    /// </summary>
+    public class GetJSProperty_InvalidType_ThrowsInvalidCastException : JSTest
+    {
+        public override void Run()
+        {
+            StubHtmlIntoTestContainer(0);
+            var doc = Document.GetDocument();
+            var div = doc.CreateElement("div").JSObject;
+
+            // Set a string property
+            JSImportInstanceHelpers.SetProperty(div, "id", "test-invalid-cast");
+
+            // Attempt to read a string property as an int[] - should throw
+            bool threwException = false;
+            try
+            {
+                var invalidResult = div.GetJSProperty<int[]>("id");
+            }
+            catch (InvalidCastException ex)
+            {
+                threwException = true;
+                Assert(ex.Message.StartsWith("Failure to coerce type returned from JS interop"), "Exception message should start with expected text");
+                Assert(ex.InnerException != null, "InnerException should not be null");
+            }
+            catch (NotImplementedException)
+            {
+                // CallJSFuncInternal throws NotImplementedException for unsupported array element types
+                threwException = true;
+            }
+
+            Assert(threwException, "GetJSProperty<int[]> on a string property should throw InvalidCastException or NotImplementedException");
+        }
+    }
+
+    /// <summary>
+    /// Tests that GetJSProperty throws InvalidCastException when requesting a JSObject from a primitive value.
+    /// </summary>
+    public class GetJSProperty_PrimitiveAsJSObject_ThrowsInvalidCastException : JSTest
+    {
+        public override void Run()
+        {
+            StubHtmlIntoTestContainer(0);
+            var doc = Document.GetDocument();
+            var div = doc.CreateElement("div").JSObject;
+
+            // Set a numeric property
+            JSImportInstanceHelpers.SetProperty(div, "testNum", 42);
+
+            // Attempt to read a numeric property as a JSObject - should throw
+            bool threwException = false;
+            try
+            {
+                var invalidResult = div.GetJSProperty<JSObject>("testNum");
+            }
+            catch (InvalidCastException ex)
+            {
+                threwException = true;
+                Assert(ex.Message.StartsWith("Failure to coerce type returned from JS interop"), "Exception message should start with expected text");
+                Assert(ex.InnerException != null, "InnerException should not be null");
+            }
+
+            Assert(threwException, "GetJSProperty<JSObject> on a numeric property should throw InvalidCastException");
+        }
+    }
+
+    /// <summary>
+    /// Tests that CallJS throws NotImplementedException when requesting an unsupported array element type.
+    /// </summary>
+    public class CallJS_UnsupportedArrayType_ThrowsNotImplementedException : JSTest
+    {
+        public override void Run()
+        {
+            StubHtmlIntoTestContainer(0);
+            var doc = Document.GetDocument();
+            var div = doc.CreateElement("div").JSObject;
+
+            // Attempt to call a function expecting an unsupported array return type (e.g., int[])
+            bool threwException = false;
+            try
+            {
+                // getAttribute returns a string, but we're asking for int[] which is unsupported
+                var invalidResult = div.CallJS<int[]>(funcName: "getAttribute", "id");
+            }
+            catch (NotImplementedException ex)
+            {
+                threwException = true;
+                Assert(ex.Message.Contains("Int32"), "Exception message should mention the unsupported element type");
+            }
+
+            Assert(threwException, "CallJS<int[]> should throw NotImplementedException for unsupported array element types");
+        }
+    }
+
+    /// <summary>
+    /// Tests that CallJS throws InvalidCastException when the JS function returns a type incompatible with the requested type.
+    /// </summary>
+    public class CallJS_IncompatibleReturnType_ThrowsInvalidCastException : JSTest
+    {
+        public override void Run()
+        {
+            StubHtmlIntoTestContainer(0);
+            var doc = Document.GetDocument();
+            var div = doc.CreateElement("div").JSObject;
+            JSImportInstanceHelpers.SetProperty(div, "id", "test-div");
+
+            // getAttribute returns a string, but we're asking for a bool
+            bool threwException = false;
+            try
+            {
+                var invalidResult = div.CallJS<bool>(funcName: "getAttribute", "id");
+            }
+            catch (InvalidCastException ex)
+            {
+                threwException = true;
+                Assert(ex.Message.StartsWith("Failure to coerce type returned from JS interop"), "Exception message should start with expected text");
+                Assert(ex.InnerException != null, "InnerException should not be null");
+            }
+
+            Assert(threwException, "CallJS<bool> when JS returns a string should throw InvalidCastException");
+        }
+    }
+}

--- a/SerratedJSInterop.Tests.WasmBrowser/0SerratedJSInterop.Tests.WasmBrowser.csproj
+++ b/SerratedJSInterop.Tests.WasmBrowser/0SerratedJSInterop.Tests.WasmBrowser.csproj
@@ -3,6 +3,10 @@
     <TargetFramework>net9.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+    <!-- AOT and trimming run only on publish (not on build). Validate with: dotnet publish -c Release -->
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <PublishTrimmed>true</PublishTrimmed>
+    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SerratedJSInterop\SerratedJSInterop.csproj" />

--- a/SerratedJSInterop/ExtensionsJSObjectCallJSReturnType.cs
+++ b/SerratedJSInterop/ExtensionsJSObjectCallJSReturnType.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SerratedSharp.SerratedJSInterop.Internal;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
@@ -6,7 +7,7 @@ namespace SerratedSharp.SerratedJSInterop;
 
 public static class ExtensionsJSObjectCallJSReturnType
 {
-    #region Overloads of inferred name CallJS<J> for 0 thru 5 parameters
+    #region Overloads of inferred name CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J> for 0 thru 5 parameters
 
     /// <summary>
     /// <para>Call JS <c>funcName</c>(inferred via [CallerMemberName]) on this JSObject.</para>
@@ -16,7 +17,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="jsObject">Reference to the JS instance to invoke funcName on.</param>
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J CallJS<J>(this JSObject jsObject, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!);
 
     /// <summary>
@@ -29,7 +30,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this JSObject jsObject, object param1, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, object param1, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, param1);
 
     /// <summary>
@@ -43,7 +44,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this JSObject jsObject, object param1, object param2, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, object param1, object param2, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, param1, param2);
 
     /// <summary>
@@ -58,7 +59,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this JSObject jsObject, object param1, object param2, object param3, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, object param1, object param2, object param3, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, param1, param2, param3);
 
     /// <summary>
@@ -74,7 +75,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this JSObject jsObject, object param1, object param2, object param3, object param4, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, object param1, object param2, object param3, object param4, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, param1, param2, param3, param4);
 
     /// <summary>
@@ -91,7 +92,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this JSObject jsObject, object param1, object param2, object param3, object param4, object param5, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, object param1, object param2, object param3, object param4, object param5, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, param1, param2, param3, param4, param5);
 
     #endregion
@@ -109,7 +110,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with casing preserved.</param>
     /// <param name="parameters">SerratedJS.JSParams bundle to pass to the JS function.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J CallJS<J>(this JSObject jsObject, string funcName, JSParams parameters)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, string funcName, JSParams parameters)
         => JSImportInstanceHelpers.CallJSFuncExplicitName<J>(jsObject, funcName, parameters.Args);
 
     // var someWrapper = this.CallJS<SomeWrapper>("someJSFunc", "param1", 25, someJSObject, someJSWrapper);
@@ -122,7 +123,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with casing preserved.</param>
     /// <param name="parameters">Arguments to pass to the JS function.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J CallJS<J>(this JSObject jsObject, string funcName, params object[] parameters)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, string funcName, params object[] parameters)
         => JSImportInstanceHelpers.CallJSFuncExplicitName<J>(jsObject, funcName, parameters);
 
     // CONSIDER: Overloads for string and int arrays, and any other array types that get unintentionally multiplexed by `params`. This may already be solved by Serrated.JSParams.ArrayParam
@@ -140,7 +141,7 @@ public static class ExtensionsJSObjectCallJSReturnType
     /// <param name="funcName">Name of the JS function on this <c>jsObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(20)]
-    public static J CallJS<J>(this JSObject jsObject, JSParams parameters, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, JSParams parameters, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(jsObject, funcName!, parameters.Args);
 
 }

--- a/SerratedJSInterop/ExtensionsJSObjectProperty.cs
+++ b/SerratedJSInterop/ExtensionsJSObjectProperty.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 
@@ -14,7 +15,7 @@ public static class ExtensionsJSObjectProperty
     /// <param name="jsObject">Reference to the JS instance to read the property from.</param>
     /// <param name="propertyName">Name of the property on this <c>jsObject</c> to get.  Omit to infer from [CallerMemberName], with first letter lower cased for JS casing conventions.</param>
     /// <returns>The property value, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J GetJSProperty<J>(this JSObject jsObject, [CallerMemberName] string? propertyName = null)
+    public static J GetJSProperty<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this JSObject jsObject, [CallerMemberName] string? propertyName = null)
         => JSImportInstanceHelpers.GetProperty<J>(jsObject, propertyName!);
 
     // this.SetJSProperty("someProperty", "value");

--- a/SerratedJSInterop/ExtensionsWrapperCallJSReturnType.cs
+++ b/SerratedJSInterop/ExtensionsWrapperCallJSReturnType.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using SerratedSharp.SerratedJSInterop.Internal;
 using System.Runtime.CompilerServices;
 
@@ -9,7 +10,7 @@ namespace SerratedSharp.SerratedJSInterop;
 public static class WrapperCallJSReturnTypeExtensions
 {
 
-    #region Overloads of inferred name CallJS<J> for 0 thru 5 parameters
+    #region Overloads of inferred name CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J> for 0 thru 5 parameters
 
     /// <summary>
     /// <para>Call JS <c>funcName</c>(inferred via [CallerMemberName]) on this IJSObjectWrapper's JSObject.</para>
@@ -19,7 +20,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="wrapper">The wrapper whose JSObject to invoke funcName on.</param>
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!);
 
     /// <summary>
@@ -32,7 +33,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, object param1, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, object param1, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, param1);
 
     /// <summary>
@@ -46,7 +47,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, object param1, object param2, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, param1, param2);
 
     /// <summary>
@@ -61,7 +62,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, param1, param2, param3);
 
     /// <summary>
@@ -77,7 +78,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, object param4, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, object param4, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, param1, param2, param3, param4);
 
     /// <summary>
@@ -94,7 +95,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(1)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, object param4, object param5, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, object param1, object param2, object param3, object param4, object param5, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, param1, param2, param3, param4, param5);
 
     #endregion
@@ -124,7 +125,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="parameters">SerratedJS.JSParams bundle to pass to the JS function.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(20)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, string funcName, JSParams parameters)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, string funcName, JSParams parameters)
         => JSImportInstanceHelpers.CallJSFuncExplicitName<J>(wrapper.JSObject, funcName, parameters.Args);
 
     /// <summary>
@@ -138,7 +139,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with casing preserved.</param>
     /// <param name="parameters">Arguments to pass to the JS function.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, string funcName, params object[] parameters)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, string funcName, params object[] parameters)
         => JSImportInstanceHelpers.CallJSFuncExplicitName<J>(wrapper.JSObject, funcName, parameters);
 
     // CONSIDER: Overloads for string and int arrays, and any other array types that get unintentionally multiplexed by `params`. This may already be solved by Serrated.JSParams.ArrayParam
@@ -155,7 +156,7 @@ public static class WrapperCallJSReturnTypeExtensions
     /// <param name="funcName">Name of the JS function on this wrapper's <c>JSObject</c> to call, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The JS call's return, casted or wrapped to requested type <c>J</c>.</returns>
     [OverloadResolutionPriority(20)]
-    public static J CallJS<J>(this IJSObjectWrapper wrapper, JSParams parameters, Breaker _ = default, [CallerMemberName] string? funcName = null)
+    public static J CallJS<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, JSParams parameters, Breaker _ = default, [CallerMemberName] string? funcName = null)
         => JSImportInstanceHelpers.CallJSFunc<J>(wrapper.JSObject, funcName!, parameters.Args);
 
 }

--- a/SerratedJSInterop/ExtensionsWrapperProperty.cs
+++ b/SerratedJSInterop/ExtensionsWrapperProperty.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace SerratedSharp.SerratedJSInterop;
@@ -12,7 +13,7 @@ public static class WrapperPropertyExtensions
     /// <param name="wrapper">The wrapper whose JSObject to read the property from.</param>
     /// <param name="propertyName">Name of the property on this wrapper's <c>JSObject</c> to get, with first letter lower cased for JS casing conventions.</param>
     /// <returns>The property value, casted or wrapped to requested type <c>J</c>.</returns>
-    public static J GetJSProperty<J>(this IJSObjectWrapper wrapper, [CallerMemberName] string? propertyName = null)
+    public static J GetJSProperty<[DynamicallyAccessedMembers(JSImportInstanceHelpers.WrapperTypeMembers)] J>(this IJSObjectWrapper wrapper, [CallerMemberName] string? propertyName = null)
         => JSImportInstanceHelpers.GetProperty<J>(wrapper.JSObject, propertyName!);
 
     /// <summary>

--- a/SerratedJSInterop/JSImportInstanceHelpers.cs
+++ b/SerratedJSInterop/JSImportInstanceHelpers.cs
@@ -5,8 +5,8 @@ namespace SerratedSharp.SerratedJSInterop;
 using System.Diagnostics.CodeAnalysis;
 using SerratedSharp.SerratedJSInterop.Internal;
 using System;
+using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 
 internal static class JSImportInstanceHelpers
@@ -42,23 +42,22 @@ internal static class JSImportInstanceHelpers
     {
         var name = applyJSCasing ? ToJSCasing(funcName) : funcName;
         object[] objs = UnwrapJSObjectParams(parameters);
-        object? genericObject;
+        object? genericObject = null;
         Type type = typeof(J);
+
         if (type.IsArray)
         {
             switch (type.GetElementType())
             {
                 case Type t when t == typeof(string):
                     genericObject = InstanceHelperJS.FuncByNameAsStringArray(jsObject, name, objs);
-                    return (J)genericObject;
+                    break;
                 case Type t when t == typeof(double):
                     genericObject = InstanceHelperJS.FuncByNameAsDoubleArray(jsObject, name, objs);
-                    return (J)genericObject;
-
-                case Type t when t == typeof(JSObject): // JSObject[] array
+                    break;
+                case Type t when t == typeof(JSObject):
                     genericObject = InstanceHelperJS.FuncByNameAsObject(jsObject, name, objs);
-                    var array = (object[])genericObject;
-                    return (J)(object)(array.Cast<JSObject>().ToArray());
+                    break;
                 default:
                     throw new NotImplementedException($"CallJSFunc: Returning array of {type.GetElementType()} not implemented");
             }
@@ -84,127 +83,156 @@ internal static class JSImportInstanceHelpers
         InstanceHelperJS.FuncByNameVoid(jsObject, name, objs);
     }
 
-    // Casts the object to J, or if J is an IJSObjectWrapper, wraps the JSObject using WrapInstance.
+    // Casts the object to J, or if J is an IJSObjectWrapper, wraps the JSObject using the cached WrapInstance delegate.
     internal static J CastOrWrap<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(object? genericObject)
     {
-        Type type = typeof(J);
+        if (genericObject is null)
+            return default!;
 
-        // Check if J implements IJSObjectWrapper<J> (only valid when J is a wrapper type; J may be JSObject or primitive)
-        Type? wrapperInterface = TryGetIJSObjectWrapperOfSelf(type);
-        if (wrapperInterface != null)
+        try
         {
-            if (genericObject is JSObject jsObj)
+            Type type = typeof(J);
+
+            // Array types: convert object[] from interop to string[], double[], or JSObject[] as requested.
+            if (type.IsArray)
             {
-                var wrapMethod = type.GetMethod("WrapInstance",
-                    BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-
-                if (wrapMethod != null)
+                Type elementType = type.GetElementType()!;
+                if (genericObject is object[] objArray)
                 {
-                    return (J)wrapMethod.Invoke(null, new object[] { jsObj })!;
+                    if (elementType == typeof(string))
+                        return (J)(object)Array.ConvertAll(objArray, o => o?.ToString() ?? "");
+                    if (elementType == typeof(double))
+                        return (J)(object)Array.ConvertAll(objArray, o => o is double d ? d : Convert.ToDouble(o));
+                    if (elementType == typeof(JSObject))
+                        return (J)(object)objArray.Cast<JSObject>().ToArray();
+                    throw new NotImplementedException($"CastOrWrap: Array of {elementType} not implemented");
                 }
+                return (J)genericObject!; // already string[] or double[] from typed interop
+            }
 
-                // Fallback: try explicit interface implementation
-                var interfaceMap = type.GetInterfaceMap(wrapperInterface);
-                for (int i = 0; i < interfaceMap.InterfaceMethods.Length; i++)
+            // If J implements IJSObjectWrapper<J> and we have a JSObject, wrap it via cached delegate
+            if (genericObject is JSObject jsObj && WrapperInvoker<J>.Wrap != null)
+                return WrapperInvoker<J>.Wrap(jsObj);
+
+            // JS interop often returns numbers as double; unboxing (int)(object)boxedDouble throws.
+            if (type.IsValueType && !type.IsEnum)
+            {
+                TypeCode code = Type.GetTypeCode(type);
+                if (code >= TypeCode.SByte && code <= TypeCode.Decimal)
                 {
-                    if (interfaceMap.InterfaceMethods[i].Name == "WrapInstance")
+                    try
                     {
-                        return (J)interfaceMap.TargetMethods[i].Invoke(null, new object[] { jsObj })!;
+                        return (J)Convert.ChangeType(genericObject, type);
+                    }
+                    catch (InvalidCastException) { /* fall through to direct cast */ }
+                }
+            }
+
+            return (J)genericObject!;
+        }
+        catch (InvalidCastException ex)
+        {
+            string sourceTypeName = genericObject?.GetType().FullName ?? "null";
+            string targetTypeName = typeof(J).FullName ?? typeof(J).Name;
+            throw new InvalidCastException(
+                $"Failure to coerce type returned from JS interop, from ({sourceTypeName}) into ({targetTypeName}). See inner exception for details.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// Per-type cached delegate for calling IJSObjectWrapper&lt;T&gt;.WrapInstance.
+    /// Reflection runs once per T when the static field initializes; all subsequent calls use the fast delegate.
+    /// </summary>
+    private static class WrapperInvoker<[DynamicallyAccessedMembers(WrapperTypeMembers)] T>
+    {
+        internal static readonly Func<JSObject, T>? Wrap = ResolveWrapper();
+
+        [UnconditionalSuppressMessage("Trimming", "IL2060",
+            Justification = "MakeGenericMethod is called with a type verified at runtime to satisfy IJSObjectWrapper<T>; T is annotated with WrapperTypeMembers.")]
+        [UnconditionalSuppressMessage("Trimming", "IL2070",
+            Justification = "T is annotated with WrapperTypeMembers which preserves Interfaces and Methods.")]
+        private static Func<JSObject, T>? ResolveWrapper()
+        {
+            Type type = typeof(T);
+            if (!typeof(IJSObjectWrapper).IsAssignableFrom(type))
+                return null;
+
+            Type openGeneric = typeof(IJSObjectWrapper<>);
+            Type[] interfaces = type.GetInterfaces();
+            for (int i = 0; i < interfaces.Length; i++)
+            {
+                Type iface = interfaces[i];
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == openGeneric)
+                {
+                    Type[] args = iface.GetGenericArguments();
+                    if (args.Length == 1 && args[0] == type)
+                    {
+                        // T implements IJSObjectWrapper<T>. Create a cached delegate that calls
+                        // the constrained TWrapper.WrapInstance via MakeGenericMethod bridge.
+                        MethodInfo openMethod = typeof(WrapperInvoker<T>)
+                            .GetMethod(nameof(CallWrapInstance), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        MethodInfo closedMethod = openMethod.MakeGenericMethod(type);
+                        return (Func<JSObject, T>)Delegate.CreateDelegate(typeof(Func<JSObject, T>), closedMethod);
                     }
                 }
             }
-
-            // If genericObject is null or not a JSObject, return default
-            return default!;
+            return null;
         }
 
-        // JS interop often returns numbers as double; unboxing (int)(object)boxedDouble throws.
-        if (genericObject != null && type.IsValueType && !type.IsEnum)
+        // Constrained bridge: the compiler can resolve TWrapper.WrapInstance here because of the constraint.
+        // Called indirectly via the cached delegate created by ResolveWrapper.
+        private static TWrapper CallWrapInstance<TWrapper>(JSObject jsObj)
+            where TWrapper : IJSObjectWrapper<TWrapper>
         {
-            TypeCode code = Type.GetTypeCode(type);
-            if (code >= TypeCode.SByte && code <= TypeCode.Decimal)
-            {
-                try
-                {
-                    return (J)Convert.ChangeType(genericObject, type);
-                }
-                catch (InvalidCastException) { /* fall through to direct cast */ }
-            }
+            return TWrapper.WrapInstance(jsObj);
         }
-
-        return (J)genericObject!;
     }
 
     public static object[] UnwrapJSObjectParams(object[] parameters)
     {
-        if(parameters == null)
+        if (parameters == null)
             return Array.Empty<object>();
 
-        // New param array with unwrapped JSOBjects if wrappers are found.  Only create array if/when we encounter first wrapper
+        // New param array with unwrapped JSObjects if wrappers are found. Only create array if/when we encounter first wrapper.
         object[]? objs = null;
         for (int i = 0; i < parameters.Length; i++)
         {
             object param = parameters[i];
             if (param is IJSObjectWrapper wrapper)
             {
-                // if first wrapper encountered, copy array up till this point
                 if (objs == null)
                     objs = TypedArrayToObjectArray(parameters, i);
 
-                objs[i] = wrapper.JSObject; // unwrap
+                objs[i] = wrapper.JSObject;
             }
-            else if (objs != null) // if we created new array for unwrapping 
+            else if (objs != null)
             {
-                // then finish copying any normal params into remainder of new array
                 objs[i] = param;
             }
         }
-        if (objs == null)
-            objs = parameters;
-        return objs;
+        return objs ?? parameters;
     }
 
     private static object[] TypedArrayToObjectArray(object[] objs, int index)
     {
         if (objs.GetType().GetElementType() == typeof(object))
-        {
             return objs;
-        }
-        else
-        {            
-            object[] objs2 = new object[objs.Length];
-            Array.Copy(objs, objs2, index + 1);
-            return objs2;
-        }
+
+        object[] objs2 = new object[objs.Length];
+        Array.Copy(objs, objs2, index + 1);
+        return objs2;
     }
 
     
-    // Returns IJSObjectWrapper&lt;T&gt; if type T implements it (i.e. T : IJSObjectWrapper<T>); otherwise null.
-    // Avoids MakeGenericType with types that don't satisfy the constraint (e.g. JSObject, primitives).
-    [return: DynamicallyAccessedMembers(WrapperTypeMembers)]
-    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2073",
-        Justification = "Returned Type is one of type.GetInterfaces(); type is annotated with WrapperTypeMembers.")]
-    private static Type? TryGetIJSObjectWrapperOfSelf([DynamicallyAccessedMembers(WrapperTypeMembers)] Type type)
-    {
-        if (!typeof(IJSObjectWrapper).IsAssignableFrom(type))
-            return null;
-
-        Type openGeneric = typeof(IJSObjectWrapper<>);
-        Type[] interfaces = type.GetInterfaces();
-        for (int i = 0; i < interfaces.Length; i++)
-        {
-            Type iface = interfaces[i];
-            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == openGeneric)
-            {
-                Type[] args = iface.GetGenericArguments();
-                if (args.Length == 1 && args[0] == type)
-                    return iface;
-            }
-        }
-        return null;
-    }
-
-    // Lower-cases first character for JS lowerCamelCase. Use CallJSFuncExplicitName/CallJSFuncVoidExplicitName or SetProperty(..., applyJSCasing: false) to preserve caller casing.
     public static string ToJSCasing(string identifier)
-        => Char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
+    {
+        if (string.IsNullOrEmpty(identifier))
+            return identifier;
+
+        if (identifier.Length == 1)
+            return char.ToLowerInvariant(identifier[0]).ToString();
+        // Lower-cases first character for JS lowerCamelCase.
+        return char.ToLowerInvariant(identifier[0]) + identifier.Substring(1);
+    }
 }

--- a/SerratedJSInterop/JSImportInstanceHelpers.cs
+++ b/SerratedJSInterop/JSImportInstanceHelpers.cs
@@ -2,6 +2,7 @@
 
 namespace SerratedSharp.SerratedJSInterop;
 
+using System.Diagnostics.CodeAnalysis;
 using SerratedSharp.SerratedJSInterop.Internal;
 using System;
 using System.Reflection;
@@ -10,9 +11,14 @@ using System.Runtime.InteropServices.JavaScript;
 
 internal static class JSImportInstanceHelpers
 {
+    /// <summary>Used by extension methods that call into CastOrWrap/GetProperty/CallJSFunc so their generic J matches trimmer requirements.</summary>
+    internal const DynamicallyAccessedMemberTypes WrapperTypeMembers =
+        DynamicallyAccessedMemberTypes.PublicMethods
+        | DynamicallyAccessedMemberTypes.NonPublicMethods
+        | DynamicallyAccessedMemberTypes.Interfaces;
 
     // J can be JSObject, primitive, or IJSObjectWrapper<J>
-    public static J GetProperty<J>(JSObject jsObject, string propertyName, bool applyJSCasing = true)
+    public static J GetProperty<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(JSObject jsObject, string propertyName, bool applyJSCasing = true)
     {
         var name = applyJSCasing ? ToJSCasing(propertyName) : propertyName;
         object? genericObject = InstanceHelperJS.PropertyByNameToObject(jsObject, name);
@@ -26,13 +32,13 @@ internal static class JSImportInstanceHelpers
     }
 
     // J should be a JSObject, IJSObjectWrapper<J>, or other primitive JS type
-    public static J CallJSFunc<J>(JSObject jsObject, string funcName, params object[] parameters)
+    public static J CallJSFunc<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(JSObject jsObject, string funcName, params object[] parameters)
         => CallJSFuncInternal<J>(jsObject, funcName, applyJSCasing: true, parameters);
 
-    public static J CallJSFuncExplicitName<J>(JSObject jsObject, string funcName, params object[] parameters)
+    public static J CallJSFuncExplicitName<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(JSObject jsObject, string funcName, params object[] parameters)
         => CallJSFuncInternal<J>(jsObject, funcName, applyJSCasing: false, parameters);
 
-    private static J CallJSFuncInternal<J>(JSObject jsObject, string funcName, bool applyJSCasing, params object[] parameters)
+    private static J CallJSFuncInternal<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(JSObject jsObject, string funcName, bool applyJSCasing, params object[] parameters)
     {
         var name = applyJSCasing ? ToJSCasing(funcName) : funcName;
         object[] objs = UnwrapJSObjectParams(parameters);
@@ -79,7 +85,7 @@ internal static class JSImportInstanceHelpers
     }
 
     // Casts the object to J, or if J is an IJSObjectWrapper, wraps the JSObject using WrapInstance.
-    internal static J CastOrWrap<J>(object? genericObject)
+    internal static J CastOrWrap<[DynamicallyAccessedMembers(WrapperTypeMembers)] J>(object? genericObject)
     {
         Type type = typeof(J);
 
@@ -175,14 +181,19 @@ internal static class JSImportInstanceHelpers
     
     // Returns IJSObjectWrapper&lt;T&gt; if type T implements it (i.e. T : IJSObjectWrapper<T>); otherwise null.
     // Avoids MakeGenericType with types that don't satisfy the constraint (e.g. JSObject, primitives).
-    private static Type? TryGetIJSObjectWrapperOfSelf(Type type)
+    [return: DynamicallyAccessedMembers(WrapperTypeMembers)]
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2073",
+        Justification = "Returned Type is one of type.GetInterfaces(); type is annotated with WrapperTypeMembers.")]
+    private static Type? TryGetIJSObjectWrapperOfSelf([DynamicallyAccessedMembers(WrapperTypeMembers)] Type type)
     {
         if (!typeof(IJSObjectWrapper).IsAssignableFrom(type))
             return null;
 
         Type openGeneric = typeof(IJSObjectWrapper<>);
-        foreach (Type iface in type.GetInterfaces())
+        Type[] interfaces = type.GetInterfaces();
+        for (int i = 0; i < interfaces.Length; i++)
         {
+            Type iface = interfaces[i];
             if (iface.IsGenericType && iface.GetGenericTypeDefinition() == openGeneric)
             {
                 Type[] args = iface.GetGenericArguments();

--- a/SerratedJSInterop/PocoMarshal.cs
+++ b/SerratedJSInterop/PocoMarshal.cs
@@ -1,4 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SerratedSharp.SerratedJSInterop;
 
@@ -11,16 +14,45 @@ internal static class PocoMarshal
 }
 
 /// <summary>
-/// Serializes a POCO to JSON (camelCase) and prefixes with SerratedPocoPrefix so JS can detect and deserialize without trying to parse every string.
+/// Serializes a POCO to JSON and prefixes with SerratedPocoPrefix so JS can detect and deserialize without trying to parse every string.
 /// </summary>
 public static class MarshalAsJsonExtensions
 {
     /// <summary>
-    /// Serializes a POCO to JSON (camelCase) and prefixes with SerratedPocoPrefix so JS can detect and deserialize without trying to parse every string.
+    /// Reflection-based serialization. Not trim-safe when used with arbitrary object types under IL trimming.
     /// </summary>
+    [RequiresUnreferencedCode("This overload uses reflection-based serialization and is not trim-safe. Favor MarshalAsJson<T>(this T, JsonTypeInfo<T>) or MarshalAsJson<T>(this T, JsonSerializerContext) when publishing trimmed apps.")]
     public static string MarshalAsJson(this object obj)
     {
         var json = JsonSerializer.Serialize(obj, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        return PocoMarshal.SerratedPocoPrefix + json;
+    }
+
+    /// <summary>
+    /// Trim-friendly serialization using a source-generated or otherwise configured JsonTypeInfo for T.
+    /// </summary>
+    public static string MarshalAsJson<T>(this T obj, JsonTypeInfo<T> jsonTypeInfo)
+    {
+        if (jsonTypeInfo is null)
+            throw new ArgumentNullException(nameof(jsonTypeInfo));
+
+        var json = JsonSerializer.Serialize(obj, jsonTypeInfo);
+        return PocoMarshal.SerratedPocoPrefix + json;
+    }
+
+    /// <summary>
+    /// Trim-friendly serialization using a JsonSerializerContext that provides type info for T.
+    /// </summary>
+    public static string MarshalAsJson<T>(this T obj, JsonSerializerContext context)
+    {
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+
+        var typeInfo = (JsonTypeInfo<T>?)context.GetTypeInfo(typeof(T));
+        if (typeInfo is null)
+            throw new InvalidOperationException($"JsonSerializerContext '{context.GetType().FullName}' does not contain metadata for type '{typeof(T).FullName}'.");
+
+        var json = JsonSerializer.Serialize(obj, typeInfo);
         return PocoMarshal.SerratedPocoPrefix + json;
     }
 }

--- a/SerratedJSInterop/SerratedJSInterop.csproj
+++ b/SerratedJSInterop/SerratedJSInterop.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -25,6 +25,7 @@
     <RepositoryUrl>https://github.com/SerratedSharp/SerratedJSInterop/tree/main/SerratedJSInterop</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <IsPackable>true</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "scripts": {
     "pack:release": "dotnet pack SerratedJSInterop.sln -c Release -o nugetpackout",
-    "pack:debug": "dotnet pack SerratedJSInterop.sln -c Debug -o nugetpackout"
+    "pack:debug": "dotnet pack SerratedJSInterop.sln -c Debug -o nugetpackout",
+    "publish:BlazorWasm": "dotnet publish SerratedJSInterop.Tests.BlazorWasm\\SerratedJSInterop.Tests.BlazorWasm.csproj -c Release -o publish\\BlazorWasm",
+    "publish:WasmBrowser": "dotnet publish SerratedJSInterop.Tests.WasmBrowser\\0SerratedJSInterop.Tests.WasmBrowser.csproj -c Release -o publish\\WasmBrowser",
+    "launchPublished:BlazorWasm": "dotnet serve -o -d publish\\BlazorWasm\\wwwroot",
+    "launchPublished:WasmBrowser": "dotnet serve -o -d publish\\WasmBrowser\\AppBundle"
   }
 }


### PR DESCRIPTION
feat: AOT and Trimming Compatible
- Sets IsTrimmable on class library
- Adds Dynamic attributes for trimming support
- Adds unit tests for validating cast failures
- Adds trimming safe overloads of MarshalAsJson
- Adjusts internal JS interop calls to:
  - Address trimming-incompatible reflection
  - Refactor array casts to also apply to SetJSProperty
- Sets the following and verified publish & dotnet serve runs all tests
```
    <RunAOTCompilation>true</RunAOTCompilation>
    <PublishTrimmed>true</PublishTrimmed>
    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
    <InvariantGlobalization>true</InvariantGlobalization>
```

Fixes https://github.com/SerratedSharp/SerratedJSInterop/issues/25
Fixes https://github.com/SerratedSharp/SerratedJSInterop/issues/20